### PR TITLE
Link to Crate charts on Helm Hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # helm-charts
-Helm charts for Kubernetes and repo for [Helm Hub](https://github.com/helm/hub).
+Helm charts for Kubernetes and repo for [Helm Hub](https://hub.helm.sh/charts/crate).
 
 Chart sources are in `/src/<chart>`, their packaged result in `/docs/<chart>`.
 


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

Link to the chart(s) on Helm Hub website makes more sense for a user of the chart than the helm/hub repo.

cf. helm/hub#162

## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
