### PR TITLE
allow configuration of a service account

### DIFF
--- a/src/crate/templates/statefulset.yaml
+++ b/src/crate/templates/statefulset.yaml
@@ -19,6 +19,9 @@ spec:
       annotations:
         pod.alpha.kubernetes.io/initialized: "true"
     spec:
+      {{- if .Values.serviceAccountName }}
+      serviceAccountName: {{ .Values.serviceAccountName }}
+      {{- end }}
       initContainers:
         - name: init-sysctl
           image: busybox
@@ -46,6 +49,8 @@ spec:
             {{- if .Values.resources.limits.cpu }}
             - -Cprocessors="$MIN_VCPU_COUNT"
             {{- end }}
+          securityContext:
+            privileged: true
           volumeMounts:
             - mountPath: /data
               name: data

--- a/src/crate/values.yaml
+++ b/src/crate/values.yaml
@@ -35,3 +35,6 @@ service:
     psql: 5432
     ui: 4200
   type: ClusterIP
+
+## Set the service account to be used. In restricted environments like openshift, it needs to be an account that allows privilege escalation.
+# serviceAccountName: crate


### PR DESCRIPTION

## Summary of the changes / Why this is an improvement
In order to use this chart in restricted k8s environments(f.e. openshift), it needs the ability to set a serviceaccount(that has the required permissions, i.e. privilege escalation). Beside that, in such environments, the main container also needs to run privileged to be able to use the 'chroot' command in the entrypoint. 

## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
